### PR TITLE
Add min-height to body to make scroll handler execute

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,3 @@
+body {
+  min-height: 100vh;
+}


### PR DESCRIPTION
## What this pullrequest does:

- When the page was zoomed out, the scroll event handler on the window that facilitates infinite scroll did not fire
- We found out that if the height of the page is less than 100%, any scroll handler does not fire
- Solution seems to be setting a min-height on the body, so the page is always at least the size of the screen

How to test:

- pull the branch
- start the app
- zoom out in the browser to 50% (far enough there there is a lot of space below the first 15 cards,
- scroll down, loading indicator should be displayed, data should be fetched

Please also test this on the current development branch to see the difference - thanks!