### PR TITLE
Prepend Public Url to og:image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,11 @@
       data-rh="true"
     />
     <meta property="og:type" content="website" data-rh="true" />
-    <meta property="og:image" content="./fndr_image.png" data-rh="true" />
+    <meta
+      property="og:image"
+      content="%PUBLIC_URL%/fndr_image.png"
+      data-rh="true"
+    />
     <meta
       property="og:url"
       content="https://fndr.netlify.app/"


### PR DESCRIPTION
## What does this PR do

- It attempts to fix the problem with the OG:image not being displayed by netlify when pasting a link in discord for example